### PR TITLE
Role string format

### DIFF
--- a/lib/ansible_utils/dependency_manager.rb
+++ b/lib/ansible_utils/dependency_manager.rb
@@ -27,7 +27,7 @@ module AnsibleUtils
       file_utils_method = action == :copy ? :copy_entry : :ln_s
 
       if !File.directory?(populate_ansible_path)
-        puts "- Ignoring role '#{path}' because it does not exist in populate-ansible"
+        puts "- Ignoring role '#{path}' because it does not exist in #{populate_ansible_path}"
       else
         dirname = File.dirname(project_path)
         if Dir.exists?(project_path)

--- a/lib/ansible_utils/playbook_helpers.rb
+++ b/lib/ansible_utils/playbook_helpers.rb
@@ -24,7 +24,7 @@ module AnsibleUtils
     end
 
     def project_folder
-      @project_folder ||= File.dirname(playbook_path)
+      @project_folder ||= Dir.pwd
     end
 
     def generic_roles_folder

--- a/lib/ansible_utils/playbook_helpers.rb
+++ b/lib/ansible_utils/playbook_helpers.rb
@@ -10,7 +10,13 @@ module AnsibleUtils
     end
 
     def paths
-      @paths ||= roles.map{|role| role['role'] }
+      @paths ||= roles.map do |role|
+        if role.is_a?(Hash)
+          role['role']
+        else
+          role
+        end
+      end
     end
 
     def roles


### PR DESCRIPTION
This PR

- supports roles defined in playbes as plain strings. i.e `- user` instead of ` - { role: 'user' }`
- changes the project dir forlder to be the current dir where the linker is executed
- changes the error message to be adaptative to the current config